### PR TITLE
Make is_correct_password more concise and Pythonic

### DIFF
--- a/source/users.rst
+++ b/source/users.rst
@@ -331,10 +331,7 @@ the hashed password stored for that user.
        # [...] columns and properties
 
        def is_correct_password(self, plaintext)
-           if bcrypt.check_password_hash(self._password, plaintext):
-               return True
-
-           return False
+           return bcrypt.check_password_hash(self._password, plaintext):
 
 Flask-Login
 ~~~~~~~~~~~


### PR DESCRIPTION
Love the book! Quick update:

```
if bool_check():
    return True
return False
```

seems like an anti-pattern, and could be replaced by `return bool_check()`
