### PR TITLE
Add missing single quotes in `assets.py` example

### DIFF
--- a/source/static.rst
+++ b/source/static.rst
@@ -119,25 +119,25 @@ We'll put these in an assets module inside our ``util`` package.
        'home_js': Bundle(
            'js/lib/jquery-1.10.2.js',
            'js/home.js',
-           output='gen/home.js),
+           output='gen/home.js'),
 
        'home_css': Bundle(
            'css/lib/reset.css',
            'css/common.css',
            'css/home.css',
-           output='gen/home.css),
+           output='gen/home.css'),
 
        'admin_js': Bundle(
            'js/lib/jquery-1.10.2.js',
            'js/lib/Chart.js',
            'js/admin.js',
-           output='gen/admin.js),
+           output='gen/admin.js'),
 
        'admin_css': Bundle(
            'css/lib/reset.css',
            'css/common.css',
            'css/admin.css',
-           output='gen/admin.css)
+           output='gen/admin.css')
    }
 
    assets = Environment(app)
@@ -157,7 +157,7 @@ Since we're registering our bundles in ``util.assets``, all we have to
 do is import that module in *\_\_init\_\_.py* after our app has been
 initialized.
 
-:: 
+::
 
     # myapp/__init__.py
 


### PR DESCRIPTION
`output` ending single quotes were missing for all the `Bundle` definitions in the `assets.py` example.