### PR TITLE
Fix error in configuration.rst

### DIFF
--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -263,7 +263,7 @@ can set up a shell script that sets our environment variables and runs
 
    # start.sh
 
-   APP_CONFIG_FILE=/var/www/yourapp/config/production.py
+   export APP_CONFIG_FILE=/var/www/yourapp/config/production.py
    python run.py
 
 *start.sh* is unique to each environment, so it should be left out of


### PR DESCRIPTION
I try to used the start.sh script proposed in this file, but it don't work on my computer (the APP_CONFIG_FILE envar was not found). After searching, I saw that I needed to export the envvar in start.sh. I don't know if it's an error, so I prefer to make a pull request if it's one.