### PR TITLE
Replace py-bcrypt with bcrypt

### DIFF
--- a/source/users.rst
+++ b/source/users.rst
@@ -176,7 +176,7 @@ practices here.
 
 We'll go ahead and use the Flask-Bcrypt extension to implement the
 bcrypt package in our application. This extension is basically just a
-wrapper around the ``py-bcrypt`` package, but it does handle a few
+wrapper around the ``bcrypt`` package, but it does handle a few
 things that would be annoying to do ourselves (like checking string
 encodings before comparing hashes).
 


### PR DESCRIPTION
Flask-Bcrypt switched to the bcrypt package:

See:

https://github.com/maxcountryman/flask-bcrypt/commit/6b9a04a22076b6c4962bcd080296e7e5c3aad3d8