### PR TITLE
Use user.email for token

### DIFF
--- a/source/users.rst
+++ b/source/users.rst
@@ -89,7 +89,7 @@ process using this method.
            # Now we'll send the email confirmation link
            subject = "Confirm your email"
 
-           token = ts.dumps(self.email, salt='email-confirm-key')
+           token = ts.dumps(user.email, salt='email-confirm-key')
 
            confirm_url = url_for(
                'confirm_email',


### PR DESCRIPTION
Likely a typo from somewhere that had reference to self, it appears corrected in the later ourapp/views.py snippet